### PR TITLE
feat: 新增垃圾摇滚（Grunge）皮肤，支持顶栏一键切换

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,11 +1,29 @@
 <template>
-  <div class="h-screen w-screen flex flex-col bg-gray-100">
+  <div class="app-shell h-screen w-screen flex flex-col bg-gray-100">
     <!-- 顶部导航栏 -->
-    <nav class="bg-white shadow-sm px-4 py-3 flex items-center justify-between">
+    <nav class="app-nav bg-white shadow-sm px-4 py-3 flex items-center justify-between">
       <div class="flex items-center space-x-4">
-        <h1 class="text-xl font-semibold text-gray-800">微信本地查看器</h1>
+        <h1 class="app-title text-xl font-semibold text-gray-800">微信本地查看器</h1>
+        <span class="app-title-sub hidden sm:inline text-xs text-gray-400">WeChat Local Viewer</span>
       </div>
       <div class="flex items-center space-x-2">
+        <!-- 皮肤切换 -->
+        <div class="theme-switch" role="group" aria-label="界面皮肤">
+          <button
+            v-for="opt in themeOptions"
+            :key="opt.value"
+            type="button"
+            class="theme-switch-btn"
+            :class="{ 'is-active': themeStore.theme === opt.value }"
+            :title="opt.hint"
+            :aria-pressed="themeStore.theme === opt.value"
+            @click="themeStore.setTheme(opt.value)"
+          >
+            <span class="theme-switch-icon">{{ opt.icon }}</span>
+            <span class="theme-switch-text">{{ opt.name }}</span>
+          </button>
+        </div>
+
         <button
           @click="settingsStore.toggleSearch()"
           class="px-3 py-2 bg-gray-100 hover:bg-gray-200 rounded-lg text-sm"
@@ -30,12 +48,12 @@
     <!-- 主内容区域 -->
     <div class="flex-1 flex overflow-hidden">
       <!-- 会话列表 -->
-      <div class="w-80 bg-white border-r border-gray-200 flex flex-col">
+      <div class="app-sidebar w-80 bg-white border-r border-gray-200 flex flex-col">
         <Home />
       </div>
 
       <!-- 聊天区域 -->
-      <div class="flex-1 flex flex-col">
+      <div class="app-chat flex-1 flex flex-col">
         <Chat />
       </div>
     </div>
@@ -60,11 +78,19 @@ import ContactsPanel from './components/ContactsPanel.vue'
 import SettingsPanel from './components/SettingsPanel.vue'
 import { useSettingsStore } from './stores/settings'
 import { useSessionStore } from './stores/session'
+import { useThemeStore, THEME_LABELS, type ThemeName } from './stores/theme'
 
 const settingsStore = useSettingsStore()
 const sessionStore = useSessionStore()
+const themeStore = useThemeStore()
+
+const themeOptions: { value: ThemeName; name: string; icon: string; hint: string }[] = [
+  { value: 'light', ...THEME_LABELS.light },
+  { value: 'grunge', ...THEME_LABELS.grunge },
+]
 
 onMounted(async () => {
+  themeStore.syncTheme()
   try {
     await sessionStore.loadSessions()
   } catch (error) {

--- a/frontend/src/components/ContactsPanel.vue
+++ b/frontend/src/components/ContactsPanel.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="fixed inset-0 bg-black bg-opacity-50 z-40" @click="close">
     <div
-      class="absolute top-20 left-1/2 -translate-x-1/2 w-[700px] max-w-[90vw] max-h-[80vh] bg-white rounded-lg shadow-xl flex flex-col"
+      class="panel-sheet absolute top-20 left-1/2 -translate-x-1/2 w-[700px] max-w-[90vw] max-h-[80vh] bg-white rounded-lg shadow-xl flex flex-col"
       @click.stop
     >
       <!-- 头部 -->

--- a/frontend/src/components/MessageBubble.vue
+++ b/frontend/src/components/MessageBubble.vue
@@ -1,16 +1,16 @@
 <template>
-  <div class="message-bubble px-4 py-2" :class="message.is_self === 1 ? 'flex justify-end' : 'flex justify-start'">
+  <div class="message-bubble px-4 py-2" :class="message.is_self === 1 ? 'flex justify-end bubble-self' : 'flex justify-start bubble-other'">
     <!-- 头像 -->
     <div
       v-if="message.is_self !== 1"
-      class="w-8 h-8 bg-gray-400 rounded-lg flex items-center justify-center text-white text-sm font-bold shrink-0"
+      class="avatar w-8 h-8 bg-gray-400 rounded-lg flex items-center justify-center text-white text-sm font-bold shrink-0"
     >
       {{ (message.sender_display_name || '未知').charAt(0) }}
     </div>
 
     <!-- 消息内容 -->
     <div
-      class="max-w-[60%] mx-2 px-3 py-2 rounded-lg shadow-sm"
+      class="bubble max-w-[60%] mx-2 px-3 py-2 rounded-lg shadow-sm"
       :class="message.is_self === 1 ? 'bg-green-200' : 'bg-white'"
     >
       <!-- 发送者名称 -->
@@ -88,7 +88,7 @@
     <!-- 自己的头像 -->
     <div
       v-if="message.is_self === 1"
-      class="w-8 h-8 bg-green-500 rounded-lg flex items-center justify-center text-white text-sm font-bold shrink-0"
+      class="avatar w-8 h-8 bg-green-500 rounded-lg flex items-center justify-center text-white text-sm font-bold shrink-0"
     >
       我
     </div>

--- a/frontend/src/components/MessageList.vue
+++ b/frontend/src/components/MessageList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="scrollerRef" class="flex-1 overflow-y-auto bg-gray-100" @scroll="onScroll">
+  <div ref="scrollerRef" class="chat-scroller flex-1 overflow-y-auto bg-gray-100" @scroll="onScroll">
     <div class="py-2">
       <div v-if="loadingMore" class="text-center py-2 text-gray-400 text-xs">加载中...</div>
       <div v-else-if="messages.length < total && messages.length > 0" class="text-center py-2 text-gray-400 text-xs">↑ 滚动加载更多</div>

--- a/frontend/src/components/SearchPanel.vue
+++ b/frontend/src/components/SearchPanel.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="fixed inset-0 bg-black bg-opacity-50 z-40" @click="close">
     <div
-      class="absolute top-20 left-1/2 -translate-x-1/2 w-[600px] max-w-[90vw] bg-white rounded-lg shadow-xl"
+      class="panel-sheet absolute top-20 left-1/2 -translate-x-1/2 w-[600px] max-w-[90vw] bg-white rounded-lg shadow-xl"
       @click.stop
     >
       <!-- 搜索输入 -->

--- a/frontend/src/components/SessionItem.vue
+++ b/frontend/src/components/SessionItem.vue
@@ -7,7 +7,7 @@
   >
     <!-- 头像 -->
     <div
-      class="w-12 h-12 rounded-lg flex items-center justify-center text-white font-bold text-lg shrink-0"
+      class="avatar w-12 h-12 rounded-lg flex items-center justify-center text-white font-bold text-lg shrink-0"
       :class="isRoom ? 'bg-green-500' : isGh ? 'bg-blue-400' : 'bg-gray-300'"
     >
       {{ session.display_name.charAt(0) }}

--- a/frontend/src/components/SettingsPanel.vue
+++ b/frontend/src/components/SettingsPanel.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="fixed inset-0 bg-black bg-opacity-50 z-40" @click="close">
     <div
-      class="absolute top-20 right-4 w-[500px] max-w-[90vw] bg-white rounded-lg shadow-xl"
+      class="panel-sheet absolute top-20 right-4 w-[500px] max-w-[90vw] bg-white rounded-lg shadow-xl"
       @click.stop
     >
       <!-- 设置头部 -->

--- a/frontend/src/grunge.css
+++ b/frontend/src/grunge.css
@@ -1,0 +1,415 @@
+/* ============================================================================
+   垃圾摇滚主题（Grunge）—— 1990s Seattle 影印志 / 拼贴海报质感
+   ----------------------------------------------------------------------------
+   仅当 <html> 上存在 .theme-grunge 时生效，默认浅色皮肤完全不受影响。
+   设计基调：炭黑脏旧的底子 + 泛黄影印纸 + 铁锈红/酸黄/苔绿点缀，
+             粗糙不规则圆角、错版印刷标题、颗粒噪点、胶带与划痕。
+   ============================================================================ */
+
+/* ---------------------------------------------------------------------------
+   1. 色板
+   --------------------------------------------------------------------------- */
+html.theme-grunge {
+  --gr-bg:       #14120f;
+  --gr-bg-2:     #1b1712;
+  --gr-panel:    #241f18;
+  --gr-panel-2:  #2e271e;
+  --gr-line:     #4a4136;
+  --gr-paper:    #d4ccb4;
+  --gr-paper-2:  #c4bb9f;
+  --gr-ink:      #1a1713;
+  --gr-rust:     #a8402a;
+  --gr-acid:     #c2b23f;
+  --gr-moss:     #77854a;
+  --gr-cyan:     #4f7f8a;
+  --gr-text:     #ded6c0;
+  --gr-text-dim: #9a917b;
+  --gr-noise: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='260' height='260'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='4' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='260' height='260' filter='url(%23n)' opacity='0.6'/%3E%3C/svg%3E");
+  --gr-scratch: repeating-linear-gradient(93deg, rgba(255, 255, 255, .05) 0 1px, transparent 1px 6px);
+  color-scheme: dark;
+}
+
+/* ---------------------------------------------------------------------------
+   2. 基础
+   --------------------------------------------------------------------------- */
+html.theme-grunge body {
+  background-color: var(--gr-bg);
+  color: var(--gr-text);
+  font-family: "Helvetica Neue", "Microsoft YaHei", "PingFang SC", Arial, sans-serif;
+}
+
+html.theme-grunge h1,
+html.theme-grunge h2,
+html.theme-grunge h3,
+html.theme-grunge h4 {
+  font-family: Georgia, "STZhongsong", "Songti SC", SimSun, serif;
+  letter-spacing: .05em;
+}
+
+html.theme-grunge ::selection {
+  background: var(--gr-acid);
+  color: #16130f;
+}
+
+html.theme-grunge ::-webkit-scrollbar { width: 12px; height: 12px; }
+html.theme-grunge ::-webkit-scrollbar-track { background: #12100d; }
+html.theme-grunge ::-webkit-scrollbar-thumb {
+  background: #4d4335;
+  border: 2px solid #12100d;
+  border-radius: 2px 8px 2px 8px;
+}
+html.theme-grunge ::-webkit-scrollbar-thumb:hover { background: var(--gr-rust); }
+
+/* 新式滚动条属性：覆盖所有可滚动容器（Chromium 会优先用这两个，忽略上面的 -webkit- 规则） */
+html.theme-grunge [class*="overflow-y-auto"],
+html.theme-grunge [class*="overflow-auto"] {
+  scrollbar-width: thin;
+  scrollbar-color: #55492f #14110d;
+}
+
+/* ---------------------------------------------------------------------------
+   3. Tailwind 颜色工具类重映射（默认面色 = 深色镀铬层）
+   --------------------------------------------------------------------------- */
+/* 带透明度后缀的 .bg-white（如灯箱关闭按钮）保持半透明，不做覆盖。
+   用 :where() 把 :not() 的权重清零，这样后面的结构钩子（.app-nav 等）能正常覆盖它 */
+html.theme-grunge .bg-white:where(:not([class*="bg-opacity"])) { background-color: var(--gr-paper); color: var(--gr-ink); }
+html.theme-grunge .bg-gray-100 { background-color: #221d17; }
+html.theme-grunge .bg-gray-50  { background-color: #1d1913; }
+html.theme-grunge .bg-gray-200 { background-color: #322b22; }
+html.theme-grunge .bg-gray-300 { background-color: #6d6555; }
+html.theme-grunge .bg-gray-400 { background-color: #57503f; }
+
+html.theme-grunge .hover\:bg-gray-200:hover { background-color: #3a3227; }
+html.theme-grunge .hover\:bg-gray-50:hover  { background-color: #2b241c; }
+html.theme-grunge .hover\:bg-gray-100:hover { background-color: #3a3227; }
+
+html.theme-grunge .text-gray-800 { color: #e6dfc9; }
+html.theme-grunge .text-gray-700 { color: #d5cbb2; }
+html.theme-grunge .text-gray-600 { color: #bdb39a; }
+html.theme-grunge .text-gray-500 { color: #a89e86; }
+html.theme-grunge .text-gray-400 { color: #8d8470; }
+html.theme-grunge .hover\:text-gray-600:hover { color: #e6dfc9; }
+
+html.theme-grunge .border,
+html.theme-grunge .border-b,
+html.theme-grunge .border-t,
+html.theme-grunge .border-r,
+html.theme-grunge .border-l { border-color: var(--gr-line); }
+html.theme-grunge .border-gray-100,
+html.theme-grunge .border-gray-200,
+html.theme-grunge .border-gray-300 { border-color: #423a2e; }
+
+/* 强调色：铁锈红（动作） / 苔绿（头像） / 酸黄（焦点） */
+html.theme-grunge .bg-green-500 { background-color: var(--gr-rust); }
+html.theme-grunge div.bg-green-500.avatar { background-color: var(--gr-moss); }
+html.theme-grunge .hover\:bg-green-600:hover { background-color: #8d3320; }
+html.theme-grunge .bg-green-300 { opacity: .7; }
+html.theme-grunge .bg-green-200 { background-color: #c9bd7c; color: #231f14; }
+html.theme-grunge .bg-green-100 { background-color: #3b4527; }
+html.theme-grunge .bg-green-50  { background-color: #2b2619; }
+html.theme-grunge .text-green-700 { color: #cdc27a; }
+html.theme-grunge .border-green-500 { border-color: var(--gr-rust); }
+
+html.theme-grunge .bg-blue-400 { background-color: var(--gr-cyan); }
+html.theme-grunge .bg-blue-100 { background-color: #2c4349; }
+html.theme-grunge .bg-blue-50  { background-color: #232019; }
+html.theme-grunge .text-blue-700 { color: #a8cbd2; }
+html.theme-grunge .text-blue-600 { color: #8fbcc6; }
+html.theme-grunge .hover\:text-blue-600:hover { color: #b9dde5; }
+
+html.theme-grunge .text-red-500 { color: #e07a5f; }
+html.theme-grunge .hover\:text-red-600:hover { color: #f09b83; }
+html.theme-grunge .text-yellow-600 { color: #d6c34c; }
+
+html.theme-grunge .disabled\:bg-gray-300:disabled { background-color: #3a3227; }
+html.theme-grunge .focus\:ring-green-500:focus { --tw-ring-color: var(--gr-acid); }
+
+/* 表单控件：泛黄影印纸 + 打字机字体 */
+html.theme-grunge input,
+html.theme-grunge select,
+html.theme-grunge textarea,
+html.theme-grunge input.bg-gray-100,
+html.theme-grunge select.bg-gray-100,
+html.theme-grunge textarea.bg-gray-100 {
+  background-color: #ece5d2;
+  color: var(--gr-ink);
+  border: 1px solid #8b8270;
+  border-radius: 2px 7px 3px 6px;
+  font-family: ui-monospace, Consolas, "Courier New", monospace;
+  letter-spacing: .02em;
+}
+html.theme-grunge input::placeholder { color: #7a7059; }
+html.theme-grunge select option { background-color: #ece5d2; color: var(--gr-ink); }
+
+/* 按钮：深色贴纸块 + 不规则圆角 + 大写字母 */
+html.theme-grunge button.bg-gray-100 {
+  background-color: #262019;
+  color: var(--gr-text);
+  border: 1px solid var(--gr-line);
+  border-radius: 2px 9px 3px 8px / 8px 3px 9px 2px;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  font-family: ui-monospace, Consolas, "Courier New", monospace;
+}
+html.theme-grunge button.bg-gray-100:hover {
+  background-color: #3a3227;
+  color: #fff8e6;
+}
+html.theme-grunge button.bg-green-500 {
+  background-color: var(--gr-rust);
+  color: #fdf6e6;
+  border: 1px solid #6d2517;
+  border-radius: 2px 9px 3px 8px / 8px 3px 9px 2px;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  font-family: ui-monospace, Consolas, "Courier New", monospace;
+  box-shadow: 2px 2px 0 rgba(0, 0, 0, .55);
+}
+html.theme-grunge button.bg-green-500:hover { background-color: #8d3320; }
+html.theme-grunge button.bg-green-500:active { box-shadow: none; transform: translate(1px, 1px); }
+
+/* ---------------------------------------------------------------------------
+   4. 皮肤切换开关（两种皮肤下都要好看）
+   --------------------------------------------------------------------------- */
+.theme-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border-radius: 10px;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+}
+.theme-switch-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  border-radius: 8px;
+  font-size: 12px;
+  line-height: 1.2;
+  color: #6b7280;
+  transition: background .15s ease, color .15s ease;
+  white-space: nowrap;
+}
+.theme-switch-btn:hover { background: #e5e7eb; color: #374151; }
+.theme-switch-btn.is-active { background: #fff; color: #111827; box-shadow: 0 1px 2px rgba(0, 0, 0, .08); }
+.theme-switch-icon { font-size: 13px; line-height: 1; }
+
+html.theme-grunge .theme-switch {
+  background: #171410;
+  border: 1px dashed var(--gr-line);
+  border-radius: 2px 9px 3px 8px;
+}
+html.theme-grunge .theme-switch-btn {
+  color: #8f8672;
+  font-family: ui-monospace, Consolas, "Courier New", monospace;
+  letter-spacing: .09em;
+  text-transform: uppercase;
+}
+html.theme-grunge .theme-switch-btn:hover { background: #2a241c; color: var(--gr-text); }
+html.theme-grunge .theme-switch-btn.is-active {
+  background: var(--gr-rust);
+  color: #f7f1e0;
+  box-shadow: inset 0 0 0 1px #621f13, 2px 2px 0 rgba(0, 0, 0, .55);
+}
+
+/* ---------------------------------------------------------------------------
+   5. 结构：外框 / 噪点 / 暗角（放在工具类之后，同权重时后者生效）
+   --------------------------------------------------------------------------- */
+html.theme-grunge .app-shell {
+  background-color: var(--gr-bg);
+  position: relative;
+}
+html.theme-grunge .app-shell::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  pointer-events: none;
+  background-image: var(--gr-noise);
+  opacity: .40;
+  mix-blend-mode: soft-light;
+}
+html.theme-grunge .app-shell::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 49;
+  pointer-events: none;
+  background: radial-gradient(125% 105% at 50% 38%, transparent 44%, rgba(0, 0, 0, .58) 100%);
+}
+
+/* 顶栏：炭黑贴纸 + 错版印刷标题 + 划痕 */
+html.theme-grunge .app-nav {
+  background-color: #17130f;
+  background-image: var(--gr-noise);
+  border-bottom: 1px solid #0b0907;
+  box-shadow: 0 3px 0 0 rgba(168, 64, 42, .6), 0 12px 24px -14px #000;
+  position: relative;
+  z-index: 51;
+  color: var(--gr-text);
+}
+html.theme-grunge .app-nav::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: var(--gr-scratch);
+  opacity: .65;
+}
+html.theme-grunge .app-nav .app-title {
+  font-family: Georgia, "STZhongsong", "Songti SC", SimSun, serif;
+  color: #f0e9d4;
+  letter-spacing: .14em;
+  text-shadow:
+    1px 0 0 rgba(168, 64, 42, .6),
+    -1px 0 0 rgba(79, 127, 138, .5),
+    0 1px 2px rgba(0, 0, 0, .7);
+  transform: rotate(-.5deg);
+}
+html.theme-grunge .app-nav .app-title-sub {
+  color: #8d8470;
+  font-family: ui-monospace, Consolas, "Courier New", monospace;
+  letter-spacing: .24em;
+  text-transform: uppercase;
+}
+html.theme-grunge .app-nav .bg-gray-100 { background-color: #241e17; }
+html.theme-grunge .app-nav .text-gray-800 { color: #e6dfc9; }
+
+/* 会话列表：黑纸封面 */
+html.theme-grunge .app-sidebar {
+  background-color: #1b1712;
+  background-image: var(--gr-noise);
+  border-right: 2px solid #0b0907;
+  box-shadow: inset -16px 0 28px -20px #000;
+  color: var(--gr-text);
+}
+
+/* 聊天区外框 */
+html.theme-grunge .app-chat {
+  background-color: var(--gr-bg-2);
+}
+
+/* 聊天头部 */
+html.theme-grunge .chat-header {
+  background-color: #1e1a14;
+  border-bottom: 1px solid #0b0907;
+  box-shadow: 0 2px 0 0 rgba(0, 0, 0, .65), 0 10px 22px -16px #000;
+  color: var(--gr-text);
+}
+html.theme-grunge .chat-header .text-gray-800 { color: #f0e9d4; }
+html.theme-grunge .chat-header .text-gray-500 { color: #b3a98e; }
+html.theme-grunge .chat-header .text-gray-400 { color: #9a917b; }
+
+/* 导出面板 */
+html.theme-grunge .export-panel {
+  background-color: #241f18;
+  border-bottom: 1px solid #0b0907;
+  color: var(--gr-text);
+}
+html.theme-grunge .export-panel .text-gray-600 { color: #bdb39a; }
+html.theme-grunge .export-panel .text-gray-400 { color: #9a917b; }
+html.theme-grunge .export-panel .border-gray-300 { border-color: var(--gr-line); }
+html.theme-grunge .export-panel button.bg-gray-100 {
+  background-color: #2c251c;
+  color: var(--gr-text);
+}
+
+/* LLM 输入条 */
+html.theme-grunge .llm-bar {
+  background-color: #1b1712;
+  border-top: 1px solid #0b0907;
+  color: var(--gr-text);
+}
+html.theme-grunge .llm-bar .bg-gray-50 { background-color: #241f18; }
+
+/* 消息流：泛黄影印纸 + 淡淡的横格线 + 咖啡渍 */
+html.theme-grunge .chat-scroller {
+  background-color: #b8b098;
+  background-image:
+    linear-gradient(rgba(60, 48, 25, .055) 1px, transparent 1px),
+    radial-gradient(150% 65% at 8% -5%, rgba(120, 88, 38, .22), transparent 62%),
+    radial-gradient(130% 60% at 95% 105%, rgba(88, 58, 22, .18), transparent 58%),
+    var(--gr-noise);
+  background-size: 100% 30px, 100% 100%, 100% 100%, 260px 260px;
+  color: #332d24;
+}
+html.theme-grunge .chat-scroller .text-gray-400 { color: #6b614c; }
+
+/* 气泡：撕纸块 */
+html.theme-grunge .bubble {
+  border-radius: 2px 12px 3px 11px / 11px 3px 12px 2px;
+  box-shadow: 1px 2px 0 rgba(0, 0, 0, .45), 0 0 0 1px rgba(0, 0, 0, .32), inset 0 0 34px rgba(120, 95, 45, .12);
+  transform: rotate(-.35deg);
+}
+html.theme-grunge .bubble-other .bubble { background-color: var(--gr-paper); color: var(--gr-ink); }
+html.theme-grunge .bubble-self .bubble {
+  background-color: #c9bd7c;
+  color: #231f14;
+  transform: rotate(.35deg);
+  box-shadow: 1px 2px 0 rgba(0, 0, 0, .45), 0 0 0 1px rgba(60, 45, 15, .4), inset 0 0 34px rgba(110, 85, 30, .16);
+}
+html.theme-grunge .bubble .text-gray-800 { color: #1a1713; }
+html.theme-grunge .bubble .text-gray-700 { color: #332d24; }
+html.theme-grunge .bubble .text-gray-600 { color: #443c2f; }
+html.theme-grunge .bubble .text-gray-500 { color: #5a5140; }
+html.theme-grunge .bubble .text-gray-400 { color: #6f6550; }
+html.theme-grunge .bubble .bg-gray-100 { background-color: #c9c1a6; }
+html.theme-grunge .bubble .border-gray-300 { border-color: #9b9276; }
+html.theme-grunge .bubble .text-xs {
+  font-family: ui-monospace, Consolas, "Courier New", monospace;
+  letter-spacing: .05em;
+}
+html.theme-grunge .bubble .rounded-lg { border-radius: 2px 8px 3px 7px; }
+
+/* 弹层：贴在桌子上的影印纸 + 胶带 */
+html.theme-grunge .panel-sheet {
+  background-color: var(--gr-paper);
+  background-image: var(--gr-noise);
+  color: var(--gr-ink);
+  border: 1px solid #6f6650;
+  border-radius: 3px 14px 4px 13px / 13px 4px 14px 3px;
+  box-shadow: 7px 8px 0 rgba(0, 0, 0, .55), 0 0 0 1px rgba(0, 0, 0, .45), inset 0 0 80px rgba(120, 95, 50, .18);
+  transform: rotate(-.5deg);
+}
+/* 注意：不要在这里写 position —— 面板靠 Tailwind 的 .absolute 定位，
+   写了 position 会把它顶掉，面板就会跑到左上角去。::before 会以它（absolute）为定位基准。 */
+html.theme-grunge .panel-sheet::before {
+  content: "";
+  position: absolute;
+  top: -13px;
+  left: 30px;
+  width: 104px;
+  height: 26px;
+  background: rgba(228, 216, 178, .55);
+  border-left: 1px dashed rgba(120, 105, 70, .5);
+  border-right: 1px dashed rgba(120, 105, 70, .5);
+  transform: rotate(-3.5deg);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, .3);
+  pointer-events: none;
+}
+html.theme-grunge .panel-sheet,
+html.theme-grunge .panel-sheet .text-gray-800 { color: var(--gr-ink); }
+html.theme-grunge .panel-sheet .text-gray-700 { color: #332d24; }
+html.theme-grunge .panel-sheet .text-gray-600 { color: #443c2f; }
+html.theme-grunge .panel-sheet .text-gray-500 { color: #5a5140; }
+html.theme-grunge .panel-sheet .text-gray-400 { color: #6f6550; }
+html.theme-grunge .panel-sheet .border-gray-200,
+html.theme-grunge .panel-sheet .border-gray-100 { border-color: #a89f86; }
+html.theme-grunge .panel-sheet .bg-gray-50 { background-color: #c8c0a6; }
+html.theme-grunge .panel-sheet .bg-gray-100 { background-color: #e6dfc9; }
+html.theme-grunge .panel-sheet .hover\:bg-gray-50:hover { background-color: #c8c0a6; }
+html.theme-grunge .panel-sheet .text-blue-600:hover,
+html.theme-grunge .panel-sheet .text-blue-600 { color: #35606b; }
+html.theme-grunge .panel-sheet .text-gray-400.hover\:text-gray-600:hover { color: #2b2519; }
+
+/* 小屏：收窄顶栏的皮肤开关 */
+@media (max-width: 720px) {
+  .theme-switch-text { display: none; }
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3,6 +3,11 @@ import { createPinia } from 'pinia'
 import App from './App.vue'
 import { router } from './router'
 import './style.css'
+import './grunge.css'
+import { readInitialTheme, applyTheme } from './stores/theme'
+
+// 首屏之前先套用主题，避免浅色闪一下再变暗
+applyTheme(readInitialTheme())
 
 const app = createApp(App)
 app.use(createPinia())

--- a/frontend/src/stores/theme.ts
+++ b/frontend/src/stores/theme.ts
@@ -1,0 +1,77 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export type ThemeName = 'light' | 'grunge'
+
+const THEME_KEY = 'wcviewer_theme_v1'
+
+/** 每个皮肤对应挂在 <html> 上的类名（light 不加类，保持默认工具类原样） */
+const THEME_CLASS: Record<ThemeName, string> = {
+  light: '',
+  grunge: 'theme-grunge',
+}
+
+const ALL_THEME_CLASSES = Object.values(THEME_CLASS).filter(Boolean)
+
+export const THEME_LABELS: Record<ThemeName, { name: string; icon: string; hint: string }> = {
+  light: { name: '原版', icon: '☀️', hint: '默认浅色皮肤' },
+  grunge: { name: '垃圾摇滚', icon: '🎸', hint: '1990s Seattle 影印志风格' },
+}
+
+function isThemeName(v: unknown): v is ThemeName {
+  return v === 'light' || v === 'grunge'
+}
+
+export function readStoredTheme(): ThemeName {
+  try {
+    const v = localStorage.getItem(THEME_KEY)
+    return isThemeName(v) ? v : 'light'
+  } catch {
+    return 'light'
+  }
+}
+
+/** 支持用 ?theme=grunge / ?theme=light 覆盖（方便分享链接或做截图比对），优先级高于本地记忆 */
+export function readInitialTheme(): ThemeName {
+  try {
+    const q = new URLSearchParams(window.location.search).get('theme')
+    if (isThemeName(q)) return q
+  } catch {
+    /* ignore */
+  }
+  return readStoredTheme()
+}
+
+/** 直接操作 <html>，独立于 Pinia，便于在 app.mount 之前调用（避免首屏闪烁） */
+export function applyTheme(name: ThemeName): void {
+  const root = document.documentElement
+  for (const cls of ALL_THEME_CLASSES) {
+    root.classList.toggle(cls, cls === THEME_CLASS[name])
+  }
+  root.setAttribute('data-theme', name)
+}
+
+export const useThemeStore = defineStore('theme', () => {
+  const theme = ref<ThemeName>(readInitialTheme())
+
+  function setTheme(name: ThemeName) {
+    theme.value = name
+    applyTheme(name)
+    try {
+      localStorage.setItem(THEME_KEY, name)
+    } catch (e) {
+      console.warn('持久化主题失败', e)
+    }
+  }
+
+  /** 在原版与垃圾摇滚皮肤之间来回切（快捷键用） */
+  function toggleTheme() {
+    setTheme(theme.value === 'light' ? 'grunge' : 'light')
+  }
+
+  function syncTheme() {
+    applyTheme(theme.value)
+  }
+
+  return { theme, setTheme, toggleTheme, syncTheme }
+})

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -14,3 +14,23 @@ html, body, #app {
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
+
+/* 皮肤开关：窄屏只留图标，避免多个主题选项把顶栏挤爆 */
+@media (max-width: 1000px) {
+  .theme-switch-text { display: none; }
+}
+
+/* 顶栏标题永不换行：皮肤可能使用更宽的中文标题字体，换行会把标题挤成两行并被裁掉 */
+.app-title {
+  white-space: nowrap;
+}
+.app-title-sub {
+  white-space: nowrap;
+}
+/* 空间不够时逐级让位：先隐藏副标题，再缩小主标题 */
+@media (max-width: 1180px) {
+  .app-title-sub { display: none; }
+}
+@media (max-width: 900px) {
+  .app-title { font-size: 16px; }
+}

--- a/frontend/src/views/Chat.vue
+++ b/frontend/src/views/Chat.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="flex-1 flex flex-col overflow-hidden">
     <!-- 聊天头部 -->
-    <div class="bg-white border-b border-gray-200 px-4 py-3 flex items-center justify-between">
+    <div class="chat-header bg-white border-b border-gray-200 px-4 py-3 flex items-center justify-between">
       <div v-if="sessionStore.currentSession" class="flex items-center space-x-3 flex-1 min-w-0">
-        <div class="w-10 h-10 bg-green-500 rounded-lg flex items-center justify-center text-white font-bold shrink-0">
+        <div class="avatar w-10 h-10 bg-green-500 rounded-lg flex items-center justify-center text-white font-bold shrink-0">
           {{ (sessionStore.currentSession.display_name || '?').charAt(0) }}
         </div>
         <div class="min-w-0">
@@ -30,7 +30,7 @@
     </div>
 
     <!-- 导出面板 -->
-    <div v-if="showExport" class="bg-white border-b border-gray-200 p-3 space-y-2 shrink-0">
+    <div v-if="showExport" class="export-panel bg-white border-b border-gray-200 p-3 space-y-2 shrink-0">
       <div class="flex items-center gap-2 text-sm">
         <label class="text-gray-600">日期：</label>
         <input v-model="exportDate" type="date"


### PR DESCRIPTION
## 功能说明

新增一个可选的 **垃圾摇滚（Grunge）皮肤**：1990s Seattle 影印志风格，可在顶栏的皮肤开关里与默认浅色皮肤一键切换。

## 实现方式

- 新增 `frontend/src/grunge.css`：全部样式挂在 `html.theme-grunge` 作用域下，**默认浅色皮肤的样式完全不受影响**，不选皮肤时零开销
- 新增 `frontend/src/stores/theme.ts`：轻量主题状态管理
  - 选择持久化到 `localStorage['wcviewer_theme_v1']`
  - 支持 `?theme=grunge` / `?theme=light` URL 参数强制指定（方便分享链接或截图比对）
  - 在 `app.mount` 之前预应用主题，避免首屏闪色
- 顶栏新增皮肤切换分段开关（☀️ 原版 / 🎸 垃圾摇滚）
- 为了让皮肤能精准覆盖，给少量关键元素加了结构钩子类（`app-nav` / `chat-header` / `avatar` / `bubble` / `panel-sheet` 等），**不改动任何原有 Tailwind 工具类**
- 窄屏适配：皮肤开关在窄屏只保留图标；顶栏标题禁止换行，空间不足时先隐藏副标题再缩小主标题

## 验证

- `npm run build` 通过
- 默认皮肤（light）视觉与原来完全一致；切到 Grunge 后整体风格生效，刷新后保持